### PR TITLE
refactor(config): use GetCurrentResourceName so the folder is not hardcoded

### DIFF
--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -121,7 +121,7 @@ namespace InfernoCollection.LaddersReborn.Client
 
             try
             {
-                configFile = API.LoadResourceFile("inferno-ladders-reborn", Globals.CONFIG_FILE_NAME);
+                configFile = API.LoadResourceFile(API.GetCurrentResourceName(), Globals.CONFIG_FILE_NAME);
             }
             catch (Exception exception)
             {

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -44,7 +44,7 @@ namespace InfernoCollection.LaddersReborn.Server
 
             try
             {
-                configFile = API.LoadResourceFile("inferno-ladders-reborn", Globals.CONFIG_FILE_NAME);
+                configFile = API.LoadResourceFile(API.GetCurrentResourceName(), Globals.CONFIG_FILE_NAME);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Having the resource name hardcoded is frowned apon, allow people to rename the folder, beyond that its their problem.